### PR TITLE
Update pom.xml

### DIFF
--- a/summerframework-redis/platform-redis-dependencies/pom.xml
+++ b/summerframework-redis/platform-redis-dependencies/pom.xml
@@ -58,6 +58,7 @@
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-configuration-processor</artifactId>
+				<version>${spring-boot.version}</version>
 				<optional>true</optional>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
add ${spring-boot.version} for 'spring-boot-configuration-processor'.
resolve build error. 
-------------------------------- 
[ERROR] Internal error: org.apache.maven.artifact.InvalidArtifactRTException: For artifact {org.springframework.boot:spring-boot-configuration-processor:null:jar}: The version cannot be empty.